### PR TITLE
Cryptography tweaks

### DIFF
--- a/cryptography/modular1.qmd
+++ b/cryptography/modular1.qmd
@@ -64,9 +64,33 @@ Prove the following statements:
 
 1. $(a + b) \equiv (p + q) \bmod n$.
 1. $(ab) \equiv (pq) \bmod n$.
-1. $(a^m) \equiv (p^m) \bmod n$, for all non-negative integers $m$.
 
-<!-- Note: the last one requires proof by induction, or a simplified form thereof. -->
+We will work through the first one.
+To do this proof, we need to use one key fact: if $a \equiv p \bmod n$, that means that there is some integer $k$ for which $a = p + cn$.
+In other words, $a$ is some multiple of $n$ plus $p$.
+
+If we do this separately for $a$ and $b$:
+$$\begin{align}
+a &= p + cn \\
+b &= q + dn
+\end{align}$$
+
+and then add these two together, we get:
+
+$$\begin{align}
+a + b &= p + q + cn + dn \\
+      &= p + q + (c + d)n
+\end{align}$$
+
+which means that $a + b$ is some multiple of $n$, plus $p + q$.
+This is exactly the same as saying $a + b \equiv p + q \bmod n$.
+
+You can use the same strategy to prove statement (2).
+
+> **Optional:** If you have studied proof by induction, try using it to show that
+> for all integers $m > 0$, $(a^m) \equiv (p^m) \bmod n$.
+
+## Applications
 
 These equalities make it far easier to perform some calculations.
 For example, what is $33^{594} \bmod{32}$?
@@ -81,6 +105,8 @@ $$33^{594} \equiv 1^{594} \equiv 1 \bmod{32},$$
 because $1$ to the power of anything is still $1$.
 
 > **Challenge:** Calculate $7^{175} \bmod{16}$.
+>
+> [If you are having trouble, try to find a pattern here: what is $7^1 \bmod 16$? and $7^2 \bmod 16$? and $7^3 \bmod 16$? Once you have found a pattern, think about why this might be the case. Can you use, for example, statement (3) above, noting that $7^{(am)} = (7^a)^m$?]
 
 <!-- The correct answer is 7, because 7^2 = 49 = (16 * 3) + 1 = 1 mod 16.
 So 7^n for any even n = 1 mod 16, and 7^n for any odd n = 7 mod 16.

--- a/cryptography/monosub.qmd
+++ b/cryptography/monosub.qmd
@@ -135,7 +135,8 @@ The frequency distribution of letters is shown to the right:
 <div id="dz">Z→ <input type="text" id="decode-z" size=1></div>
 </div>
 <div class="centred-container"><div id="decode-remaining" style="text-align: center;"></div></div>
-<br />
+
+**Hint:** Once you have put together a few letters, look out for common, repeating, two- or three-letter patterns. The most common set of three letters in English is "THE". Can you find anywhere where this word might fit?
 
 The first 800 characters from the text above are shown here.
 In each of the lines below, the upper character represents the cipher text, and the lower character is the decoded plain text:

--- a/cryptography/styles.css
+++ b/cryptography/styles.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Itim&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;700&family=Itim&family=Open+Sans:ital,wght@0,400;0,600;1,400;1,600&display=swap');
 
 p {
     font-family: 'Open Sans', sans-serif;
@@ -10,7 +10,7 @@ p {
 }
 
 .is_code {
-    font-family: 'Fira Code', monospace;
+    font-family: 'Fira Mono', monospace;
 }
 
 .fullwidth {

--- a/cryptography/vigenere_encode.js
+++ b/cryptography/vigenere_encode.js
@@ -77,9 +77,5 @@ function splitByKeyLength() {
     }
 }
 
-//document.getElementById("key-encode").addEventListener("input", cleanKey);
-// document.getElementById("key-decode").addEventListener("input",  e => cleanKey("key-decode"));
-//document.getElementById("input-encode").addEventListener("input", splitByKeyLength);
-//document.getElementById("key-encode").addEventListener("input", encrypt);
-//document.getElementById("input-encode").addEventListener("input", encrypt);
+document.getElementById("key-decode").addEventListener("input", (_) => cleanKey("key-decode"));
 document.getElementById("key-decode").addEventListener("input",  decrypt);

--- a/website/cryptography.qmd
+++ b/website/cryptography.qmd
@@ -21,6 +21,10 @@ In the first half of the day, we’ll be going through symmetric ciphers: these 
 
 In the second half, we’ll talk about asymmetric ciphers, where you and the recipient do not actually share a key. Although this might sound like a contradiction, this is possible, and is really important for the modern Internet, as you don’t want to be sending your key over the Internet where anybody can read it!
 
+Modern cryptography is founded upon mathematics: in particular, we will spend some time discussing modular arithmetic and how it can be used to generate keys for asymmetric encryption.
+If you are the sort of person who likes to know what’s going on under the hood, then this may be the challenge for you!
+However, fret not if you are not a mathematician: we will be providing you with all the tools you need to complete the challenge.
+
 ## Getting Started
 
 To get started, head over to the [Cryptography challenge website](https://alan-turing-institute.github.io/summer-experience-challenges/cryptography/).


### PR DESCRIPTION
I've made several edits based on discussions we had & observations from last Thursday. The commit messages should explain, but TL;DR -

- added a bit to the website description
- made Modular I more gentle, spelling out one of the proofs and offering a hint for the final question
- added a hint to monoalphabetic. I think people had fun on this but it was definitely one of the parts in the first half which could be sped up
- couple of bugfixes

One thing I didn't do in the notes, but you might want to consider for the actual session, is to make Modular II optional (especially if the aim is to get to the game at the end). While it's nice to be able to teach the Euclidean algorithm, it might not be so necessary if they can just get a computer to solve it. If it's skipped it might also be a nice take home activity for anyone who's really keen.

I'm on leave from 4–15 Aug so please feel free to edit and merge when you're happy!